### PR TITLE
Add .gitignore entries for sensitive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,3 @@ dist-ssr
 # Environment and secrets
 .env
 .env.*
-*.pem
-*.key
-*.p12
-*.pfx
-credentials.json
-service-account*.json

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,13 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment and secrets
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+credentials.json
+service-account*.json


### PR DESCRIPTION
The .gitignore is missing entries for `.env` files and private keys (`*.pem`, `*.key`). Added those along with a few other common credential patterns to help prevent accidental commits.